### PR TITLE
Fixed #38548 -- Updated DomainNameValidator to require entire string to be a valid domain name

### DIFF
--- a/django/core/validators.py
+++ b/django/core/validators.py
@@ -101,13 +101,16 @@ class DomainNameValidator(RegexValidator):
 
         if self.accept_idna:
             self.regex = _lazy_re_compile(
-                self.hostname_re + self.domain_re + self.tld_re, re.IGNORECASE
+                r"^" + self.hostname_re + self.domain_re + self.tld_re + r"$",
+                re.IGNORECASE,
             )
         else:
             self.regex = _lazy_re_compile(
-                self.ascii_only_hostname_re
+                r"^"
+                + self.ascii_only_hostname_re
                 + self.ascii_only_domain_re
-                + self.ascii_only_tld_re,
+                + self.ascii_only_tld_re
+                + r"$",
                 re.IGNORECASE,
             )
         super().__init__(**kwargs)

--- a/docs/releases/5.1.3.txt
+++ b/docs/releases/5.1.3.txt
@@ -10,4 +10,7 @@ Django 5.1.3 fixes several bugs in 5.1.2 and adds compatibility with Python
 Bugfixes
 ========
 
-* ...
+* Fixed a bug in Django 5.1 where
+  :class:`~django.core.validators.DomainNameValidator` accepted any input value
+  that contained a valid domain name, rather than only input values that were a
+  valid domain name (:ticket:`35845`).

--- a/tests/validators/tests.py
+++ b/tests/validators/tests.py
@@ -635,8 +635,8 @@ TEST_DATA = [
     (validate_domain_name, "python-python.com", None),
     (validate_domain_name, "python.name.uk", None),
     (validate_domain_name, "python.tips", None),
-    (validate_domain_name, "http://例子.测试", None),
-    (validate_domain_name, "http://dashinpunytld.xn---c", None),
+    (validate_domain_name, "例子.测试", None),
+    (validate_domain_name, "dashinpunytld.xn---c", None),
     (validate_domain_name, "python..org", ValidationError),
     (validate_domain_name, "python-.org", ValidationError),
     (validate_domain_name, "too-long-name." * 20 + "com", ValidationError),
@@ -652,6 +652,16 @@ TEST_DATA = [
     ),
     (DomainNameValidator(accept_idna=False), "ıçğü.com", ValidationError),
     (DomainNameValidator(accept_idna=False), "not-domain-name", ValidationError),
+    (
+        DomainNameValidator(accept_idna=False),
+        "not-domain-name, but-has-domain-name-suffix.com",
+        ValidationError,
+    ),
+    (
+        DomainNameValidator(accept_idna=False),
+        "not-domain-name.com, but has domain prefix",
+        ValidationError,
+    ),
 ]
 
 # Add valid and invalid URL tests.


### PR DESCRIPTION
#### Trac ticket number

ticket-35845

#### Branch description

This PR fixes an issue where `DomainNameValidator` would erroneously validate any string that contained a valid domain name, rather than requiring that the entire string be a valid domain name.

#### Checklist
- [x] This PR targets the `main` branch. 
- [x] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [x] I have checked the "Has patch" ticket flag in the Trac system.
- [x] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
